### PR TITLE
Add models and codecs for BER identifiers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,5 +6,27 @@ val commonSettings = Seq(
 lazy val scalaLdapCore = (project in file("scala-ldap-core"))
   .settings(
     commonSettings,
-    name := "scala-ldap-core"
+    name := "scala-ldap-core",
+    libraryDependencies ++= Seq(
+      "org.scodec" %% "scodec-core" % "1.11.7",
+      "org.scodec" %% "scodec-bits" % "1.1.20",
+      "org.scodec" %% "scodec-core-testkit" % "1.11.4" % Test,
+      "org.scalactic" %% "scalactic" % "3.2.0" % Test,
+      "org.scalatest" %% "scalatest" % "3.2.0" % Test
+    )
+  )
+
+lazy val scalaLdapClient = (project in file("scala-ldap-client"))
+  .settings(
+    commonSettings,
+    name := "scala-ldap-client",
+    libraryDependencies ++= Seq(
+      "com.spinoco" %% "protocol-ldap" % "0.4.0-M1",
+      "org.typelevel" %% "cats-core" % "2.0.0",
+      "co.fs2" %% "fs2-core" % "2.4.4",
+      "co.fs2" %% "fs2-io" % "2.4.4",
+      "org.scodec" %% "scodec-stream" % "2.0.0",
+      "org.scalactic" %% "scalactic" % "3.2.0" % Test,
+      "org.scalatest" %% "scalatest" % "3.2.0" % Test
+    )
   )

--- a/scala-ldap-core/src/main/scala/wolfendale/ber/Identifier.scala
+++ b/scala-ldap-core/src/main/scala/wolfendale/ber/Identifier.scala
@@ -1,0 +1,207 @@
+package wolfendale.ber
+
+import scodec.{Attempt, Codec, Err}
+
+sealed abstract class TagClass
+
+object TagClass {
+
+  case object Universal extends TagClass
+  case object Application extends TagClass
+  case object ContextSpecific extends TagClass
+  case object Private extends TagClass
+
+  val codec: Codec[TagClass] = {
+    import scodec.codecs._
+    uint2.exmap({
+      case 0 => Attempt.successful(Universal)
+      case 1 => Attempt.successful(Application)
+      case 2 => Attempt.successful(ContextSpecific)
+      case 3 => Attempt.successful(Private)
+      case _ => Attempt.failure(Err("Impossible"))
+    }, {
+      case Universal       => Attempt.successful(0)
+      case Application     => Attempt.successful(1)
+      case ContextSpecific => Attempt.successful(2)
+      case Private         => Attempt.successful(3)
+    })
+  }
+}
+
+sealed abstract class TagType {
+  val constructionType: ConstructionType
+}
+
+object TagType {
+
+  sealed abstract class WithConstructionType(val constructionType: ConstructionType) extends TagType
+
+  case object EOC extends TagType.WithConstructionType(ConstructionType.Primitive)
+  case object Boolean extends TagType.WithConstructionType(ConstructionType.Primitive)
+  case object Integer extends TagType.WithConstructionType(ConstructionType.Primitive)
+  final case class BitString(constructionType: ConstructionType) extends TagType
+  final case class OctetString(constructionType: ConstructionType) extends TagType
+  case object Null extends TagType.WithConstructionType(ConstructionType.Primitive)
+  case object ObjectId extends TagType.WithConstructionType(ConstructionType.Primitive)
+  final case class ObjectDescriptor(constructionType: ConstructionType) extends TagType
+  case object External extends TagType.WithConstructionType(ConstructionType.Constructed)
+  case object Real extends TagType.WithConstructionType(ConstructionType.Primitive)
+  case object Enumerated extends TagType.WithConstructionType(ConstructionType.Primitive)
+  case object EmbeddedPdv extends TagType.WithConstructionType(ConstructionType.Constructed)
+  final case class Utf8String(constructionType: ConstructionType) extends TagType
+  case object RelativeOid extends TagType.WithConstructionType(ConstructionType.Primitive)
+  case object Time extends TagType.WithConstructionType(ConstructionType.Primitive)
+  case object Sequence extends TagType.WithConstructionType(ConstructionType.Constructed)
+  case object Set extends TagType.WithConstructionType(ConstructionType.Constructed)
+  final case class NumericString(constructionType: ConstructionType) extends TagType
+  final case class PrintableString(constructionType: ConstructionType) extends TagType
+  final case class T61String(constructionType: ConstructionType) extends TagType
+  final case class VideotexString(constructionType: ConstructionType) extends TagType
+  final case class IA5String(constructionType: ConstructionType) extends TagType
+  final case class UtcTime(constructionType: ConstructionType) extends TagType
+  final case class GeneralizedTime(constructionType: ConstructionType) extends TagType
+  final case class GraphicString(constructionType: ConstructionType) extends TagType
+  final case class VisibleString(constructionType: ConstructionType) extends TagType
+  final case class GeneralString(constructionType: ConstructionType) extends TagType
+  final case class UniversalString(constructionType: ConstructionType) extends TagType
+  case object CharacterString extends TagType.WithConstructionType(ConstructionType.Constructed)
+  final case class BmpString(constructionType: ConstructionType) extends TagType
+  case object Date extends TagType.WithConstructionType(ConstructionType.Primitive)
+  case object TimeOfDay extends TagType.WithConstructionType(ConstructionType.Primitive)
+  case object DateTime extends TagType.WithConstructionType(ConstructionType.Primitive)
+  case object Duration extends TagType.WithConstructionType(ConstructionType.Primitive)
+  case object OidIri extends TagType.WithConstructionType(ConstructionType.Primitive)
+  case object RelativeOidIri extends TagType.WithConstructionType(ConstructionType.Primitive)
+  final case class Other(constructionType: ConstructionType, tagNumber: Int) extends TagType
+
+  private val tagNumber: Codec[Int] = {
+    import scodec.bits._
+    import scodec.codecs._
+    val longTag: Codec[Int] = (constant(bin"11111") ~ berInt).exmap(
+      { case (_, int)        => Attempt.successful(int) },
+      { case int if int > 30 => Attempt.successful(() -> int)
+        case _               => Attempt.failure(Err("Invalid tag type length"))
+      }
+    )
+    choice(longTag, uint(5))
+  }
+
+  val otherTagType: Codec[TagType] =
+    (ConstructionType.codec ~ tagNumber).exmap(
+      Other.tupled.andThen(Attempt.successful),
+      { case Other(ct, tn) => Attempt.successful((ct, tn))
+        case _             => Attempt.failure(Err("Unable to encode universal tag type with generic codec"))
+      }
+    )
+
+  val universalTagTypeCodec: Codec[TagType] = {
+    (ConstructionType.codec ~ tagNumber).exmap({
+      case (ConstructionType.Primitive, 0)    => Attempt.successful(TagType.EOC)
+      case (ConstructionType.Primitive, 1)    => Attempt.successful(TagType.Boolean)
+      case (ConstructionType.Primitive, 2)    => Attempt.successful(TagType.Integer)
+      case (constructionType, 3)              => Attempt.successful(TagType.BitString(constructionType))
+      case (constructionType, 4)              => Attempt.successful(TagType.OctetString(constructionType))
+      case (ConstructionType.Primitive, 5)    => Attempt.successful(TagType.Null)
+      case (ConstructionType.Primitive, 6)    => Attempt.successful(TagType.ObjectId)
+      case (constructionType, 7)              => Attempt.successful(TagType.ObjectDescriptor(constructionType))
+      case (ConstructionType.Constructed, 8)  => Attempt.successful(TagType.External)
+      case (ConstructionType.Primitive, 9)    => Attempt.successful(TagType.Real)
+      case (ConstructionType.Primitive, 10)   => Attempt.successful(TagType.Enumerated)
+      case (ConstructionType.Constructed, 11) => Attempt.successful(TagType.EmbeddedPdv)
+      case (constructionType, 12)             => Attempt.successful(TagType.Utf8String(constructionType))
+      case (ConstructionType.Primitive, 13)   => Attempt.successful(TagType.RelativeOid)
+      case (ConstructionType.Primitive, 14)   => Attempt.successful(TagType.Time)
+      case (ConstructionType.Constructed, 16) => Attempt.successful(TagType.Sequence)
+      case (ConstructionType.Constructed, 17) => Attempt.successful(TagType.Set)
+      case (constructionType, 18)             => Attempt.successful(TagType.NumericString(constructionType))
+      case (constructionType, 19)             => Attempt.successful(TagType.PrintableString(constructionType))
+      case (constructionType, 20)             => Attempt.successful(TagType.T61String(constructionType))
+      case (constructionType, 21)             => Attempt.successful(TagType.VideotexString(constructionType))
+      case (constructionType, 22)             => Attempt.successful(TagType.IA5String(constructionType))
+      case (constructionType, 23)             => Attempt.successful(TagType.UtcTime(constructionType))
+      case (constructionType, 24)             => Attempt.successful(TagType.GeneralizedTime(constructionType))
+      case (constructionType, 25)             => Attempt.successful(TagType.GraphicString(constructionType))
+      case (constructionType, 26)             => Attempt.successful(TagType.VisibleString(constructionType))
+      case (constructionType, 27)             => Attempt.successful(TagType.GeneralString(constructionType))
+      case (constructionType, 28)             => Attempt.successful(TagType.UniversalString(constructionType))
+      case (ConstructionType.Constructed, 29) => Attempt.successful(TagType.CharacterString)
+      case (constructionType, 30)             => Attempt.successful(TagType.BmpString(constructionType))
+      case (ConstructionType.Primitive, 31)   => Attempt.successful(TagType.Date)
+      case (ConstructionType.Primitive, 32)   => Attempt.successful(TagType.TimeOfDay)
+      case (ConstructionType.Primitive, 33)   => Attempt.successful(TagType.DateTime)
+      case (ConstructionType.Primitive, 34)   => Attempt.successful(TagType.Duration)
+      case (ConstructionType.Primitive, 35)   => Attempt.successful(TagType.OidIri)
+      case (ConstructionType.Primitive, 36)   => Attempt.successful(TagType.RelativeOidIri)
+      case _                                  => Attempt.failure(Err("Invalid tag type"))
+    }, {
+      case TagType.EOC                                => Attempt.successful((ConstructionType.Primitive, 0))
+      case TagType.Boolean                            => Attempt.successful((ConstructionType.Primitive, 1))
+      case TagType.Integer                            => Attempt.successful((ConstructionType.Primitive, 2))
+      case TagType.BitString(constructionType)        => Attempt.successful((constructionType, 3))
+      case TagType.OctetString(constructionType)      => Attempt.successful((constructionType, 4))
+      case TagType.Null                               => Attempt.successful((ConstructionType.Primitive, 5))
+      case TagType.ObjectId                           => Attempt.successful((ConstructionType.Primitive, 6))
+      case TagType.ObjectDescriptor(constructionType) => Attempt.successful((constructionType, 7))
+      case TagType.External                           => Attempt.successful((ConstructionType.Constructed, 8))
+      case TagType.Real                               => Attempt.successful((ConstructionType.Primitive, 9))
+      case TagType.Enumerated                         => Attempt.successful((ConstructionType.Primitive, 10))
+      case TagType.EmbeddedPdv                        => Attempt.successful((ConstructionType.Constructed, 11))
+      case TagType.Utf8String(constructionType)       => Attempt.successful((constructionType, 12))
+      case TagType.RelativeOid                        => Attempt.successful((ConstructionType.Primitive, 13))
+      case TagType.Time                               => Attempt.successful((ConstructionType.Primitive, 14))
+      case TagType.Sequence                           => Attempt.successful((ConstructionType.Constructed, 16))
+      case TagType.Set                                => Attempt.successful((ConstructionType.Constructed, 17))
+      case TagType.NumericString(constructionType)    => Attempt.successful((constructionType, 18))
+      case TagType.PrintableString(constructionType)  => Attempt.successful((constructionType, 19))
+      case TagType.T61String(constructionType)        => Attempt.successful((constructionType, 20))
+      case TagType.VideotexString(constructionType)   => Attempt.successful((constructionType, 21))
+      case TagType.IA5String(constructionType)        => Attempt.successful((constructionType, 22))
+      case TagType.UtcTime(constructionType)          => Attempt.successful((constructionType, 23))
+      case TagType.GeneralizedTime(constructionType)  => Attempt.successful((constructionType, 24))
+      case TagType.GraphicString(constructionType)    => Attempt.successful((constructionType, 25))
+      case TagType.VisibleString(constructionType)    => Attempt.successful((constructionType, 26))
+      case TagType.GeneralString(constructionType)    => Attempt.successful((constructionType, 27))
+      case TagType.UniversalString(constructionType)  => Attempt.successful((constructionType, 28))
+      case TagType.CharacterString                    => Attempt.successful((ConstructionType.Constructed, 29))
+      case TagType.BmpString(constructionType)        => Attempt.successful((constructionType, 30))
+      case TagType.Date                               => Attempt.successful((ConstructionType.Primitive, 31))
+      case TagType.TimeOfDay                          => Attempt.successful((ConstructionType.Primitive, 32))
+      case TagType.DateTime                           => Attempt.successful((ConstructionType.Primitive, 33))
+      case TagType.Duration                           => Attempt.successful((ConstructionType.Primitive, 34))
+      case TagType.OidIri                             => Attempt.successful((ConstructionType.Primitive, 35))
+      case TagType.RelativeOidIri                     => Attempt.successful((ConstructionType.Primitive, 36))
+      case _                                          => Attempt.failure(Err("Invalid Universal Tag"))
+    })
+  }
+}
+
+sealed abstract class ConstructionType
+
+object ConstructionType {
+
+  case object Primitive extends ConstructionType
+  case object Constructed extends ConstructionType
+
+  val codec: Codec[ConstructionType] = {
+    import scodec.codecs._
+    bool.xmap({
+      case false => Primitive
+      case true  => Constructed
+    }, {
+      case Primitive   => false
+      case Constructed => true
+    })
+  }
+}
+
+final case class Identifier(tagClass: TagClass, tagType: TagType)
+
+object Identifier extends ((TagClass, TagType) => Identifier) {
+
+  val codec: Codec[Identifier] = {
+    TagClass.codec.flatZip {
+      case TagClass.Universal => TagType.universalTagTypeCodec
+      case _                  => TagType.otherTagType
+    }.xmap(Identifier.tupled, Function.unlift(Identifier.unapply))
+  }
+}

--- a/scala-ldap-core/src/main/scala/wolfendale/ber/package.scala
+++ b/scala-ldap-core/src/main/scala/wolfendale/ber/package.scala
@@ -1,0 +1,43 @@
+package wolfendale
+
+import scodec.{Attempt, Codec, DecodeResult, SizeBound}
+import scodec.bits._
+import scodec.codecs._
+
+import scala.annotation.tailrec
+
+package object ber {
+
+  def berInt: Codec[Int] = new Codec[Int] {
+
+    override def sizeBound: SizeBound = SizeBound.bounded(8, 8 * 5)
+
+    override def encode(value: Int): Attempt[BitVector] =
+      runEncode(BitVector.empty, value)
+
+    override def decode(bits: BitVector): Attempt[DecodeResult[Int]] =
+      runDecode(bits, 0)
+
+    @tailrec
+    private def runDecode(buffer: BitVector, value: Int): Attempt[DecodeResult[Int]] = {
+      val result = buffer.sliceToInt(1, 7, signed = false) + (value << 7)
+      if (buffer.get(0)) {
+        runDecode(buffer.drop(8), result)
+      } else Attempt.successful {
+        DecodeResult(result, buffer.drop(8))
+      }
+    }
+
+    /* 10000000 */
+    private val MoreOctets = 128
+
+    @tailrec
+    private def runEncode(buffer: BitVector, value: Int): Attempt[BitVector] = {
+      if (buffer.isEmpty) {
+        runEncode(BitVector.fromInt(value & ~MoreOctets, 8), value >> 7)
+      } else if (Integer.compareUnsigned(value, 0) > 0) {
+        runEncode(buffer.splice(0, BitVector.fromInt(value | MoreOctets, 8)), value >> 7)
+      } else Attempt.successful(buffer)
+    }
+  }
+}

--- a/scala-ldap-core/src/test/scala/wolfendale/EncodingAssertions.scala
+++ b/scala-ldap-core/src/test/scala/wolfendale/EncodingAssertions.scala
@@ -1,0 +1,26 @@
+package wolfendale
+
+import org.scalatest._
+import matchers.must._
+import freespec._
+import scodec.Codec
+import scodec.bits.BitVector
+import wolfendale.ber.TagType
+
+trait EncodingAssertions { self: AnyFreeSpec with Matchers =>
+
+  def mustEncode[A](codec: Codec[A], value: A, binary: BitVector): Unit = {
+    s"must encode to ${binary.toBin}" in {
+      val result = codec.encode(value)
+      result.isSuccessful mustBe true
+      result.require mustEqual binary
+    }
+
+    s"must decode from ${binary.toBin}" in {
+      val result = codec.decode(binary)
+      result.isSuccessful mustBe true
+      result.require.remainder mustBe BitVector.empty
+      result.require.value mustBe value
+    }
+  }
+}

--- a/scala-ldap-core/src/test/scala/wolfendale/ber/BerTest.scala
+++ b/scala-ldap-core/src/test/scala/wolfendale/ber/BerTest.scala
@@ -1,0 +1,25 @@
+package wolfendale.ber
+
+import org.scalatest._
+import freespec._
+import matchers.must._
+import scodec.bits._
+import wolfendale.EncodingAssertions
+
+class BerTest extends AnyFreeSpec with Matchers with EncodingAssertions {
+
+  "berInt" - {
+
+    "0" - mustEncode(berInt, 0, bin"00000000")
+    "1" - mustEncode(berInt, 1, bin"00000001")
+    "127" - mustEncode(berInt, 127, bin"01111111")
+    "128" - mustEncode(berInt, 128, bin"10000001 00000000")
+    "16383" - mustEncode(berInt, 16383, bin"11111111 01111111")
+    "16384" - mustEncode(berInt, 16384, bin"10000001 10000000 00000000")
+    "Int.MaxValue" - mustEncode(berInt, Int.MaxValue, bin"10000111 11111111 11111111 11111111 01111111")
+
+    "Binary strings which would decode to a value greater than Int.MaxValue must fail instead" ignore {
+      // TODO
+    }
+  }
+}

--- a/scala-ldap-core/src/test/scala/wolfendale/ber/IdentifierTest.scala
+++ b/scala-ldap-core/src/test/scala/wolfendale/ber/IdentifierTest.scala
@@ -1,0 +1,163 @@
+package wolfendale.ber
+
+import org.scalatest._
+import freespec._
+import matchers.must._
+import scodec.bits._
+import wolfendale.EncodingAssertions
+
+class IdentifierTest extends AnyFreeSpec with Matchers with EncodingAssertions {
+
+  "ConstructionType" - {
+    "Primitive" - mustEncode(ConstructionType.codec, ConstructionType.Primitive, BitVector.low(1))
+    "Constructed" - mustEncode(ConstructionType.codec, ConstructionType.Constructed, BitVector.high(1))
+  }
+
+  "Tag Class" - {
+    "Universal" - mustEncode(TagClass.codec, TagClass.Universal, bin"00")
+    "Application" - mustEncode(TagClass.codec, TagClass.Application, bin"01")
+    "ContextSpecific" - mustEncode(TagClass.codec, TagClass.ContextSpecific, bin"10")
+    "Private" - mustEncode(TagClass.codec, TagClass.Private, bin"11")
+  }
+
+  "Universal TagType" - {
+
+    def mustEncodeTagType(tagType: TagType, binary: BitVector): Unit =
+      mustEncode(TagType.universalTagTypeCodec, tagType, binary)
+
+    "EOC" - mustEncodeTagType(TagType.EOC, bin"000000")
+    "Boolean" - mustEncodeTagType(TagType.Boolean, bin"000001")
+    "Integer" - mustEncodeTagType(TagType.Integer, bin"000010")
+
+    "BitString" -{
+      mustEncodeTagType(TagType.BitString(ConstructionType.Primitive), bin"000011")
+      mustEncodeTagType(TagType.BitString(ConstructionType.Constructed), bin"100011")
+    }
+
+    "OctetString" - {
+      mustEncodeTagType(TagType.OctetString(ConstructionType.Primitive), bin"000100")
+      mustEncodeTagType(TagType.OctetString(ConstructionType.Constructed), bin"100100")
+    }
+
+    "Null" - mustEncodeTagType(TagType.Null, bin"000101")
+    "ObjectId" - mustEncodeTagType(TagType.ObjectId, bin"000110")
+
+    "ObjectDescriptor" - {
+      mustEncodeTagType(TagType.ObjectDescriptor(ConstructionType.Primitive), bin"000111")
+      mustEncodeTagType(TagType.ObjectDescriptor(ConstructionType.Constructed), bin"100111")
+    }
+
+    "External" - mustEncodeTagType(TagType.External, bin"101000")
+    "Real" - mustEncodeTagType(TagType.Real, bin"001001")
+    "Enumerated" - mustEncodeTagType(TagType.Enumerated, bin"001010")
+    "EmbeddedPdv" - mustEncodeTagType(TagType.EmbeddedPdv, bin"101011")
+
+    "Utf8String" - {
+      mustEncodeTagType(TagType.Utf8String(ConstructionType.Primitive), bin"001100")
+      mustEncodeTagType(TagType.Utf8String(ConstructionType.Constructed), bin"101100")
+    }
+
+    "RelativeOid" - mustEncodeTagType(TagType.RelativeOid, bin"001101")
+    "Time" - mustEncodeTagType(TagType.Time, bin"001110")
+
+    "Reserved" - {
+
+      "must fail to decode reserved value" in {
+        TagType.universalTagTypeCodec.decode(bin"001111").isFailure mustBe true
+        TagType.universalTagTypeCodec.decode(bin"101111").isFailure mustBe true
+      }
+    }
+
+    "Sequence" - mustEncodeTagType(TagType.Sequence, bin"110000")
+    "Set" - mustEncodeTagType(TagType.Set, bin"110001")
+
+    "NumericString" - {
+      mustEncodeTagType(TagType.NumericString(ConstructionType.Primitive), bin"010010")
+      mustEncodeTagType(TagType.NumericString(ConstructionType.Constructed), bin"110010")
+    }
+
+    "PrintableString" - {
+      mustEncodeTagType(TagType.PrintableString(ConstructionType.Primitive), bin"010011")
+      mustEncodeTagType(TagType.PrintableString(ConstructionType.Constructed), bin"110011")
+    }
+
+    "T61String" - {
+      mustEncodeTagType(TagType.T61String(ConstructionType.Primitive), bin"010100")
+      mustEncodeTagType(TagType.T61String(ConstructionType.Constructed), bin"110100")
+    }
+
+    "VideotexString" - {
+      mustEncodeTagType(TagType.VideotexString(ConstructionType.Primitive), bin"010101")
+      mustEncodeTagType(TagType.VideotexString(ConstructionType.Constructed), bin"110101")
+    }
+
+    "IA5String" - {
+      mustEncodeTagType(TagType.IA5String(ConstructionType.Primitive), bin"010110")
+      mustEncodeTagType(TagType.IA5String(ConstructionType.Constructed), bin"110110")
+    }
+
+    "UTCTime" - {
+      mustEncodeTagType(TagType.UtcTime(ConstructionType.Primitive), bin"010111")
+      mustEncodeTagType(TagType.UtcTime(ConstructionType.Constructed), bin"110111")
+    }
+
+    "GeneralizedTime" - {
+      mustEncodeTagType(TagType.GeneralizedTime(ConstructionType.Primitive), bin"011000")
+      mustEncodeTagType(TagType.GeneralizedTime(ConstructionType.Constructed), bin"111000")
+    }
+
+    "GraphicString" - {
+      mustEncodeTagType(TagType.GraphicString(ConstructionType.Primitive), bin"011001")
+      mustEncodeTagType(TagType.GraphicString(ConstructionType.Constructed), bin"111001")
+    }
+
+    "VisibleString" - {
+      mustEncodeTagType(TagType.VisibleString(ConstructionType.Primitive), bin"011010")
+      mustEncodeTagType(TagType.VisibleString(ConstructionType.Constructed), bin"111010")
+    }
+
+    "GeneralString" - {
+      mustEncodeTagType(TagType.GeneralString(ConstructionType.Primitive), bin"011011")
+      mustEncodeTagType(TagType.GeneralString(ConstructionType.Constructed), bin"111011")
+    }
+
+    "UniversalString" - {
+      mustEncodeTagType(TagType.UniversalString(ConstructionType.Primitive), bin"011100")
+      mustEncodeTagType(TagType.UniversalString(ConstructionType.Constructed), bin"111100")
+    }
+
+    "CharacterString" -{
+      mustEncodeTagType(TagType.CharacterString, bin"111101")
+    }
+
+    "BmpString" - {
+      mustEncodeTagType(TagType.BmpString(ConstructionType.Primitive), bin"011110")
+      mustEncodeTagType(TagType.BmpString(ConstructionType.Constructed), bin"111110")
+    }
+
+    "Date" - mustEncodeTagType(TagType.Date, bin"011111 00011111")
+    "TimeOfDay" - mustEncodeTagType(TagType.TimeOfDay, bin"011111 00100000")
+    "DateTime" - mustEncodeTagType(TagType.DateTime, bin"011111 00100001")
+    "Duration" - mustEncodeTagType(TagType.Duration, bin"011111 00100010")
+    "OidIri" - mustEncodeTagType(TagType.OidIri, bin"011111 00100011")
+    "RelativeOidIri" - mustEncodeTagType(TagType.RelativeOidIri, bin"011111 00100100")
+  }
+
+  "Other Tag Type" - {
+    mustEncode(TagType.otherTagType, TagType.Other(ConstructionType.Primitive, 0), bin"000000")
+    mustEncode(TagType.otherTagType, TagType.Other(ConstructionType.Constructed, 0), bin"100000")
+    mustEncode(TagType.otherTagType, TagType.Other(ConstructionType.Primitive, 30), bin"011110")
+    mustEncode(TagType.otherTagType, TagType.Other(ConstructionType.Primitive, 31), bin"011111 00011111")
+  }
+
+  "Identifier" - {
+
+    "A universal identifier" - {
+      mustEncode(Identifier.codec, Identifier(TagClass.Universal, TagType.EOC), bin"00000000")
+    }
+
+    "A non-universal identifier" - {
+      mustEncode(Identifier.codec, Identifier(TagClass.Application, TagType.Other(ConstructionType.Primitive, 0)), bin"01000000")
+    }
+  }
+}


### PR DESCRIPTION
This is the first part of the [BER encoding scheme](https://en.wikipedia.org/wiki/X.690#BER_encoding) used by the LDAP protocol